### PR TITLE
Allow missing hashes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: yarn-lock
-version: 0.6.0
+version: 0.6.1
 github: Profpatsch/yarn-lock
 license: MIT
 license-file: LICENSE
@@ -20,7 +20,7 @@ dependencies:
   - base == 4.*
   - containers
   - text
-  - megaparsec == 6.*
+  - megaparsec == 7.*
   - protolude == 0.2.*
   - either >= 4 && < 6
 

--- a/src/Yarn/Lock.hs
+++ b/src/Yarn/Lock.hs
@@ -81,7 +81,7 @@ prettyLockfileError = \case
 
 -- helpers
 astParse :: FilePath -> Text -> Either LockfileError [Parse.Package]
-astParse fp = first (ParseError . toS . MP.parseErrorPretty)
+astParse fp = first (ParseError . toS . MP.errorBundlePretty)
                 . MP.parse Parse.packageList fp
 
 toPackages :: [Parse.Package] -> Either LockfileError [T.Keyed T.Package]

--- a/src/Yarn/Lock/File.hs
+++ b/src/Yarn/Lock/File.hs
@@ -154,8 +154,7 @@ astToPackage = V.validationToEither . validate
         checkFileLocal :: Maybe T.Remote
         checkFileLocal = do
           resolved <- vToM $ getField text "resolved" fs
-          let (file, mayHash) = findUrlHash resolved
-          fileLocalSha1 <- mayHash
+          let (file, fileLocalSha1) = findUrlHash resolved
           fileLocalPath <- if "file:" `Text.isPrefixOf` file
                            then Just $ noPrefix "file:" file
                            else Nothing
@@ -164,8 +163,7 @@ astToPackage = V.validationToEither . validate
         checkFile :: Maybe T.Remote
         checkFile = do
           resolved <- vToM (getField text "resolved" fs)
-          let (fileUrl, mayFileSha1) = findUrlHash resolved
-          fileSha1 <- mayFileSha1
+          let (fileUrl, fileSha1) = findUrlHash resolved
           pure $ T.FileRemote{..}
 
         -- | ensure the prefix is removed

--- a/src/Yarn/Lock/Parse.hs
+++ b/src/Yarn/Lock/Parse.hs
@@ -80,7 +80,7 @@ packageList = MP.many $ (skipMany (comment <|> MP.string "\n")) *> packageEntry
 -- @
 packageEntry :: Parser (YLT.Keyed (SourcePos, PackageFields))
 packageEntry = label "package entry" $ do
-  pos <- getPosition
+  pos <- getSourcePos
   -- A package entry is a non-indented
   (keys, pkgs) <- nonIndented
             -- block that has a header of package keys

--- a/src/Yarn/Lock/Types.hs
+++ b/src/Yarn/Lock/Types.hs
@@ -66,8 +66,11 @@ data Package = Package
 data Remote
   = FileRemote
   { fileUrl     :: Text -- ^ URL to a remote file
-  , fileSha1    :: Maybe Text -- ^ sha1 hash of the file (attached to the link)
+  , fileSha1    :: Text -- ^ sha1 hash of the file (attached to the link)
 
+  }
+  | FileRemoteNoIntegrity
+  { fileNoIntegrityUrl :: Text -- ^ URL to a remote file
   }
   | GitRemote
   { gitRepoUrl  :: Text -- ^ valid git remote URL
@@ -76,5 +79,8 @@ data Remote
   -- this is a bit of an oddidity, but what isn’t
   | FileLocal
   { fileLocalPath :: Text -- ^ (relative) path to file on the local machine
-  , fileLocalSha1 :: Maybe Text -- ^ sha1 hash of the file (attached to the link)
+  , fileLocalSha1 :: Text -- ^ sha1 hash of the file (attached to the link)
+  }
+  | FileLocalNoIntegrity
+  { fileLocalNoIntegrityPath :: Text -- ^ (relative) path to file on the local machine
   } deriving (Eq, Show)

--- a/src/Yarn/Lock/Types.hs
+++ b/src/Yarn/Lock/Types.hs
@@ -66,7 +66,7 @@ data Package = Package
 data Remote
   = FileRemote
   { fileUrl     :: Text -- ^ URL to a remote file
-  , fileSha1    :: Text -- ^ sha1 hash of the file (attached to the link)
+  , fileSha1    :: Maybe Text -- ^ sha1 hash of the file (attached to the link)
 
   }
   | GitRemote
@@ -76,5 +76,5 @@ data Remote
   -- this is a bit of an oddidity, but what isn’t
   | FileLocal
   { fileLocalPath :: Text -- ^ (relative) path to file on the local machine
-  , fileLocalSha1 :: Text -- ^ sha1 hash of the file (attached to the link)
+  , fileLocalSha1 :: Maybe Text -- ^ sha1 hash of the file (attached to the link)
   } deriving (Eq, Show)

--- a/tests/TestFile.hs
+++ b/tests/TestFile.hs
@@ -51,15 +51,17 @@ case_fileRemote = do
   let sha = "helloimref"
       good = minimalAst $
           [ ("resolved", Left $ "https://gnu.org/stallmanstoe#" <> sha) ]
-      goodNoHash = minimalAst $
+      goodNoIntegrity = minimalAst $
           [ ("resolved", Left $ "https://gnu.org/stallmanstoe") ]
   astToPackageSuccess good
     <&> T.remote >>= \case
-      T.FileRemote{..} -> assertEqual "file sha" (Just sha) fileSha1
+      T.FileRemote{..} -> do
+        assertEqual "remote url" "https://gnu.org/stallmanstoe" fileUrl
+        assertEqual "file sha" sha fileSha1
       a -> assertFailure ("should be FileRemote, is " <> show a)
-  astToPackageSuccess goodNoHash
+  astToPackageSuccess goodNoIntegrity
     <&> T.remote >>= \case
-      T.FileRemote{..} -> assertEqual "file sha" Nothing fileSha1
+      T.FileRemoteNoIntegrity{..} -> assertEqual "remote url" "https://gnu.org/stallmanstoe" fileNoIntegrityUrl
       a -> assertFailure ("should be FileRemote, is " <> show a)
 
 case_fileLocal :: Assertion
@@ -67,20 +69,19 @@ case_fileLocal = do
   let good = minimalAst $
         [ ("resolved"
           , Left $ "file:../extensions/jupyterlab-toc-0.6.0.tgz#393fe") ]
-      goodNoHash = minimalAst $
+      goodNoIntegrity = minimalAst $
         [ ("resolved"
           , Left $ "file:../extensions/jupyterlab-toc-0.6.0.tgz") ]
   astToPackageSuccess good
     <&> T.remote >>= \case
       T.FileLocal{..} -> do
         assertEqual "file path" "../extensions/jupyterlab-toc-0.6.0.tgz" fileLocalPath
-        assertEqual "file sha" (Just "393fe") fileLocalSha1
+        assertEqual "file sha" "393fe" fileLocalSha1
       a -> assertFailure ("should be FileLocal, is " <> show a)
-  astToPackageSuccess goodNoHash
+  astToPackageSuccess goodNoIntegrity
     <&> T.remote >>= \case
-      T.FileLocal{..} -> do
-        assertEqual "file path" "../extensions/jupyterlab-toc-0.6.0.tgz" fileLocalPath
-        assertEqual "file sha" Nothing fileLocalSha1
+      T.FileLocalNoIntegrity{..} -> do
+        assertEqual "file path" "../extensions/jupyterlab-toc-0.6.0.tgz" fileLocalNoIntegrityPath
       a -> assertFailure ("should be FileLocal, is " <> show a)
 
 case_missingField :: Assertion

--- a/tests/TestParse.hs
+++ b/tests/TestParse.hs
@@ -142,7 +142,7 @@ parseSuccess parser string = do
     (Right a) -> pure a
     (Left err) -> do
       _ <- assertFailure ("parse should succeed, but: \n"
-                    <> MP.parseErrorPretty err
+                    <> MP.errorBundlePretty err
                     <> "for input\n" <> toS string <> "\n\"")
       panic "not reached"
 


### PR DESCRIPTION
(this includes the commit from my other PR that updates to Megaparsec 7.*)

yarn.lock allows hashes to be omitted in the `resolved` field, so I made them optional