### PR TITLE
Update Megaparsec dependency to >= 7 && < 9

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ dependencies:
   - base == 4.*
   - containers
   - text
-  - megaparsec == 7.*
+  - megaparsec >= 7 && < 9
   - protolude == 0.2.*
   - either >= 4 && < 6
 


### PR DESCRIPTION
bumped megaparsec dependency; the tests also pass on 8.x