### PR TITLE
Relax bounds to fix build with current stackage-nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /dist-newstyle/
-/yarn-lock.cabal
 /Setup*

--- a/package.yaml
+++ b/package.yaml
@@ -20,8 +20,8 @@ dependencies:
   - base == 4.*
   - containers
   - text
-  - megaparsec >= 7 && < 9
-  - protolude == 0.2.*
+  - megaparsec >= 7 && < 10
+  - protolude >= 0.2 && < 0.4
   - either >= 4 && < 6
 
 library:

--- a/yarn-lock.cabal
+++ b/yarn-lock.cabal
@@ -1,0 +1,74 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           yarn-lock
+version:        0.6.2
+synopsis:       Represent and parse yarn.lock files
+description:    Types and parser for the lock file format of the npm successor yarn. All modules should be imported qualified.
+category:       Data
+homepage:       https://github.com/Profpatsch/yarn-lock#readme
+bug-reports:    https://github.com/Profpatsch/yarn-lock/issues
+author:         Profpatsch
+maintainer:     mail@profpatsch.de
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/Profpatsch/yarn-lock
+
+library
+  exposed-modules:
+      Data.MultiKeyedMap
+      Yarn.Lock
+      Yarn.Lock.File
+      Yarn.Lock.Helpers
+      Yarn.Lock.Parse
+      Yarn.Lock.Types
+  other-modules:
+      Paths_yarn_lock
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base ==4.*
+    , containers
+    , either >=4 && <6
+    , megaparsec >=7 && <10
+    , protolude >=0.2 && <0.4
+    , text
+  default-language: Haskell2010
+
+test-suite yarn-lock-tests
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  other-modules:
+      TestFile
+      TestMultiKeyedMap
+      TestParse
+      Paths_yarn_lock
+  hs-source-dirs:
+      tests
+  ghc-options: -Wall
+  build-depends:
+      ansi-wl-pprint >=0.6
+    , base ==4.*
+    , containers
+    , either >=4 && <6
+    , megaparsec >=7 && <10
+    , neat-interpolation >=0.3
+    , protolude
+    , quickcheck-instances ==0.3.*
+    , tasty >=0.11
+    , tasty-hunit >=0.9
+    , tasty-quickcheck >=0.8
+    , tasty-th >=0.1.7
+    , text
+    , yarn-lock
+  default-language: Haskell2010


### PR DESCRIPTION
New release would be nice although build in `haskellPackages` can currently be fixed by a `doJailbreak`.

Resolves #8.